### PR TITLE
Teknofu/issue18

### DIFF
--- a/src/pages/ChoreManagement.jsx
+++ b/src/pages/ChoreManagement.jsx
@@ -420,6 +420,26 @@ const ChoreManagement = () => {
     }
   };
 
+  const getNextScheduledDay = (scheduledDays) => {
+    if (!scheduledDays) return null;
+    
+    const today = new Date().toLocaleString('en-US', { weekday: 'long' });
+    const daysOrder = [...DAYS_OF_WEEK]; // Use our existing DAYS_OF_WEEK array
+    
+    // Find today's index
+    const todayIndex = daysOrder.indexOf(today);
+    
+    // Check each day starting from tomorrow
+    for (let i = 1; i <= 7; i++) {
+      const nextIndex = (todayIndex + i) % 7;
+      const nextDay = daysOrder[nextIndex];
+      if (scheduledDays[nextDay]) {
+        return nextDay;
+      }
+    }
+    return null;
+  };
+
   const renderChildSelect = () => (
     <FormControl fullWidth sx={{ mb: 2 }}>
       <InputLabel>Assign To</InputLabel>
@@ -611,7 +631,9 @@ const ChoreManagement = () => {
                                 .map(([day]) => day)
                                 .includes(new Date().toLocaleString('en-US', { weekday: 'long' }))
                             ? "Today"
-                            : "Next scheduled day"}
+                            : getNextScheduledDay(chore.scheduledDays) 
+                              ? `Next ${getNextScheduledDay(chore.scheduledDays)}`
+                              : "No days scheduled"}
                         </Typography>
                       )}
                     </Grid>


### PR DESCRIPTION
Daily logic fixed:
For daily chores (chore.timeframe === "daily"), it will always show "Due: Today"
For monthly chores, it continues to show the start date
For weekly chores, it shows "Today" if the current day is scheduled, otherwise "Next scheduled day"

Added Dynamic next scheduled day to Due: text
Takes the scheduledDays object as input
Gets today's day name and finds its index in our DAYS_OF_WEEK array
Loops through the next 7 days starting from tomorrow
Returns the next scheduled day name, or null if no days are scheduled
Updated the due date display logic to:
Show "Due: Today" for daily chores
Show the start date for monthly chores
For weekly chores:
Show "Today" if the chore is scheduled for today
Show "Next Monday" (or whatever the next scheduled day is) if there's a future scheduled day
Show "No days scheduled" if no days are scheduled at all