### PR TITLE
Feature Fix: display name of chore in Financial Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,7 @@
   - PaymentProcessor
   - EarningsOverview
 - Removed deprecated defaultProps pattern to prevent future React warnings
+
+### Fixed
+- Transaction history now shows actual chore name instead of generic "chore" type in the description field
+- Reset button in chore management now includes a refresh icon for better visual clarity

--- a/src/components/Financial/TransactionHistory.jsx
+++ b/src/components/Financial/TransactionHistory.jsx
@@ -57,7 +57,9 @@ const TransactionHistory = ({
       ...earning,
       type: 'earning',
       date: earning.createdAt,
-      description: earning.source?.type || 'Unknown earning'
+      description: earning.source?.type === 'chore' 
+        ? earning.source?.choreName || 'Unnamed Chore'
+        : earning.source?.type || 'Unknown earning'
     })),
     ...payments.map(payment => ({
       ...payment,

--- a/src/pages/ChoreManagement.jsx
+++ b/src/pages/ChoreManagement.jsx
@@ -843,6 +843,7 @@ const ChoreManagement = () => {
                                 variant="outlined"
                                 color="warning"
                                 onClick={() => handleManualChoreReset(chore.id)}
+                                startIcon={<RefreshIcon />}
                               >
                                 Reset
                               </Button>


### PR DESCRIPTION
### Fixed
- Transaction history now shows actual chore name instead of generic "chore" type in the description field
- Reset button in chore management now includes a refresh icon for better visual clarity