### PR TITLE
Status not being set on new chore creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,8 @@
 - Fixed uncaught TypeError when selecting days in weekly chore schedule
   - Properly initialize scheduledDays when switching to weekly timeframe
   - Ensure scheduledDays object exists before accessing properties
+
+## 2025-02-04
+
+### Fixed
+- Bug fix: Added initial 'pending' status when creating new chores to ensure proper status tracking

--- a/src/services/chores.js
+++ b/src/services/chores.js
@@ -41,7 +41,8 @@ export const createChore = async (choreData, schedulePattern = null) => {
       createdBy: user.uid,
       parentAccess: [user.uid], // Initialize with creator's access
       createdAt: serverTimestamp(),
-      updatedAt: serverTimestamp()
+      updatedAt: serverTimestamp(),
+      status: 'pending'
     };
 
     // Add schedule if provided


### PR DESCRIPTION
## 2025-02-04

### Fixed
- Bug fix: Added initial 'pending' status when creating new chores to ensure proper status tracking